### PR TITLE
feat: use bigger images in example

### DIFF
--- a/docs/dist/donate-button/0.2/index.html
+++ b/docs/dist/donate-button/0.2/index.html
@@ -29,7 +29,7 @@
                 amount: '25',
                 bgColor: '#BCD9DD',
                 img:
-                  'https://images.unsplash.com/photo-1546500840-ae38253aba9b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1600&q=80',
+                  'https://images.unsplash.com/photo-1535507903430-1d1b9ce3bcb9?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=700&q=80',
               },
               {
                 amount: '50',
@@ -42,7 +42,7 @@
                 amount: '100',
                 bgColor: '#A0CBFE',
                 img:
-                  'https://images.unsplash.com/photo-1598846019232-a5752b94c3af?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1575&q=80',
+                  'https://images.unsplash.com/photo-1515555585025-54136276b6e3?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=634&q=80',
               },
               {
                 amount: 'custom',

--- a/packages/donate-button/src/public/index.html
+++ b/packages/donate-button/src/public/index.html
@@ -34,7 +34,7 @@
                 amount: '25',
                 bgColor: '#BCD9DD',
                 img:
-                  'https://images.unsplash.com/photo-1546500840-ae38253aba9b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1600&q=80',
+                  'https://images.unsplash.com/photo-1535507903430-1d1b9ce3bcb9?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=700&q=80',
               },
               {
                 amount: '50',
@@ -47,7 +47,7 @@
                 amount: '100',
                 bgColor: '#A0CBFE',
                 img:
-                  'https://images.unsplash.com/photo-1598846019232-a5752b94c3af?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1575&q=80',
+                  'https://images.unsplash.com/photo-1515555585025-54136276b6e3?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=634&q=80',
               },
               {
                 amount: 'custom',


### PR DESCRIPTION
@osdiab I saw the issue #101. The reason of why the images doesn't look very well is because they don't have a good aspect ratio. I changed the images and now they are shown as it should be, for sure that we can improve this designs but at least with this the images are shown as expected

![image](https://user-images.githubusercontent.com/27377635/109166335-5cf19e80-775b-11eb-9cc0-2e6d478aaa24.png)
