### PR TITLE
initial widget layout. frequency component

### DIFF
--- a/packages/donate-button-beta/src/components/widget/Frequency/index.tsx
+++ b/packages/donate-button-beta/src/components/widget/Frequency/index.tsx
@@ -1,0 +1,104 @@
+import cxs from 'cxs';
+import {useState} from 'preact/hooks';
+import {Fragment} from 'preact/jsx-runtime';
+import {COLORS} from 'src/components/widget/theme/colors.enum';
+
+const frequencyContainerCss = cxs({
+	display: 'flex'
+});
+
+const labelCss = cxs({
+	color: COLORS.Primary,
+	fontSize: '1rem',
+	lineHeight: 1.5,
+	fontWeight: 400,
+	letterSpacing: '-0.01em',
+	padding: '8px 0px',
+	flex: 1,
+	textAlign: 'center',
+	border: '1px solid',
+	borderColor: COLORS.LightGray,
+	transition: 'all .2s'
+});
+
+const labelSelectedCss = cxs({
+	borderColor: COLORS.Primary
+});
+
+const separatorBorderSelectedCss = cxs({
+	borderRightColor: COLORS.Primary
+});
+
+const labelLeftCss = cxs({
+	borderRadius: '0.5rem 0 0 0.5rem'
+});
+
+const labelRightCss = cxs({
+	borderRadius: '0 0.5rem 0.5rem 0',
+	borderLeft: 'none'
+});
+
+const inputCss = cxs({
+	display: 'none'
+});
+
+const titleCss = cxs({
+	margin: 0,
+	fontSize: '1rem',
+	lineHeight: 1.5,
+	marginBottom: '0.5rem',
+	color: COLORS.Text
+});
+
+export const Frequency = () => {
+	const [selected, setSelected] = useState('');
+
+	const labelSeparatorClass =
+		selected === 'monthly' || selected === 'one-time'
+			? [separatorBorderSelectedCss]
+			: [];
+	const leftLabelClasses = [labelCss, labelLeftCss].concat(
+		selected === 'monthly' ? [labelSelectedCss] : []
+	);
+	const rightLabelClasses = [labelCss, labelRightCss].concat(
+		selected === 'one-time' ? [labelSelectedCss] : []
+	);
+
+	return (
+		<Fragment>
+			<p className={titleCss}>Frequency</p>
+			<div className={frequencyContainerCss}>
+				<label
+					className={leftLabelClasses.concat(labelSeparatorClass).join(' ')}
+					htmlFor="monthly"
+					onClick={() => {
+						setSelected('monthly');
+					}}
+				>
+					<input
+						className={inputCss}
+						type="radio"
+						name="frequency"
+						value="monthly"
+					/>
+					Monthly
+				</label>
+				<label
+					className={rightLabelClasses.join(' ')}
+					htmlFor="one-time"
+					onClick={() => {
+						setSelected('one-time');
+					}}
+				>
+					<input
+						className={inputCss}
+						type="radio"
+						name="frequency"
+						value="one-time"
+					/>
+					One-time
+				</label>
+			</div>
+		</Fragment>
+	);
+};

--- a/packages/donate-button-beta/src/components/widget/index.tsx
+++ b/packages/donate-button-beta/src/components/widget/index.tsx
@@ -1,0 +1,55 @@
+import cxs from 'cxs';
+import {Frequency} from 'src/components/widget/Frequency';
+import {COLORS} from 'src/components/widget/theme/colors.enum';
+
+cxs.prefix('edoWidget-');
+
+const wrapperCss = cxs({
+	position: 'absolute',
+	height: '100vh',
+	width: '100vh',
+	zIndex: 999,
+	top: 0,
+	bottom: 0,
+	left: 0,
+	right: 0,
+	display: 'flex',
+	background: 'rgba(0, 0, 0, 0.5)',
+	justifyContent: 'center',
+	alignItems: 'center',
+	fontFamily: `Basis Grotesque Pro, -apple-system, BlinkMacSystemFont,
+    Segoe UI, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Roboto,
+    sans-serif`
+});
+
+const widgetCss = cxs({
+	// Temporary until we have more content inside the widget
+	height: '70vh',
+	width: '60vw',
+
+	display: 'grid',
+	gridTemplateColumns: '60% 40%',
+	background: 'white',
+	borderRadius: '24px'
+});
+
+const formCss = cxs({
+	gridColumn: '1 / 2',
+	borderRight: `1px solid ${COLORS.LightGray}`,
+	padding: '1.5rem'
+});
+
+const Widget = ({show}: {show: boolean}) => {
+	return show ? (
+		<div className={wrapperCss}>
+			<form className={widgetCss}>
+				<div className={formCss}>
+					<Frequency />
+				</div>
+				<div>WIP</div>
+			</form>
+		</div>
+	) : null;
+};
+
+export default Widget;

--- a/packages/donate-button-beta/src/components/widget/theme/colors.enum.ts
+++ b/packages/donate-button-beta/src/components/widget/theme/colors.enum.ts
@@ -1,0 +1,5 @@
+export enum COLORS {
+	Primary = '#00A37F',
+	LightGray = '#EAEDED',
+	Text = '#2E3434'
+}

--- a/packages/donate-button-beta/src/index.tsx
+++ b/packages/donate-button-beta/src/index.tsx
@@ -1,5 +1,6 @@
 import {render} from 'preact';
 import EmbedButton from 'src/components/embed-button';
+import Widget from 'src/components/widget';
 import {
 	DonateButtonOptions,
 	EmbedButtonOptions
@@ -120,9 +121,37 @@ function initButtons() {
 	}
 }
 
+let mountPoint: HTMLElement;
+const options = {
+	show: false
+};
+const showWidget = () => {
+	Object.assign(options, {show: true});
+
+	renderWidget();
+};
+
+const mount = () => {
+	// We don't attach directly to body because is hiding the elements inside the body for some reason.
+	const widgetWrapper = document.createElement('div');
+	document.body.append(widgetWrapper);
+
+	mountPoint = document.createElement('div');
+	widgetWrapper.append(mountPoint);
+};
+
+const renderWidget = () => {
+	if (!mountPoint) {
+		mount();
+	}
+
+	render(<Widget {...options} />, mountPoint);
+};
+
 interface GlobalExport {
 	createButton: typeof createButtonInSelector;
 	initButtons: typeof initButtons;
+	showWidget: typeof showWidget;
 }
 
 declare const window: Window & {
@@ -131,5 +160,6 @@ declare const window: Window & {
 
 window.everyDotOrgDonateButton = {
 	createButton: createButtonInSelector,
-	initButtons
+	initButtons,
+	showWidget
 };


### PR DESCRIPTION
closes #154 

@osdiab The way of show the widget is just for development purposes, once we have a better idea and advances of the widget we can modify it to a more definitive version. 
Can we set vercel to automatically deploy the new widget instead of the old one, so we can test it on the preview?

Also I removed the shadow DOM. I think that will not be necessary anymore because we are encapsulating the styles