### PR TITLE
feat: use only one default donation amount

### DIFF
--- a/packages/donate-button-beta/src/components/widget/Frequency/index.tsx
+++ b/packages/donate-button-beta/src/components/widget/Frequency/index.tsx
@@ -57,13 +57,8 @@ interface FrequencyProps {
 }
 
 export const Frequency = ({frequency, setFrequency}: FrequencyProps) => {
-	const {
-		showFrequencyPopover,
-		dismissPopover,
-		setDonationAmount
-	} = useWidgetContext();
-
-	const {defaultDonationAmounts, primaryColor} = useConfigContext();
+	const {showFrequencyPopover, dismissPopover} = useWidgetContext();
+	const {primaryColor} = useConfigContext();
 	const i18n = useI18n();
 
 	const frequencyPopover = useRef<HTMLDivElement>(null);
@@ -94,7 +89,6 @@ export const Frequency = ({frequency, setFrequency}: FrequencyProps) => {
 				onClick={() => {
 					if (showFrequencyPopover) dismissPopover();
 					setFrequency(DonationFrequency.Monthly);
-					setDonationAmount(defaultDonationAmounts.monthly);
 				}}
 			>
 				<input
@@ -111,7 +105,6 @@ export const Frequency = ({frequency, setFrequency}: FrequencyProps) => {
 				onClick={() => {
 					if (showFrequencyPopover) dismissPopover();
 					setFrequency(DonationFrequency.OneTime);
-					setDonationAmount(defaultDonationAmounts.oneTime);
 				}}
 			>
 				<input

--- a/packages/donate-button-beta/src/components/widget/index.tsx
+++ b/packages/donate-button-beta/src/components/widget/index.tsx
@@ -181,7 +181,7 @@ const Widget = ({options, hide}: WidgetProps) => {
 		config.showInitialMessage
 	);
 	const [donationAmount, setDonationAmount] = useState<number>(
-		config.defaultDonationAmounts.monthly
+		config.defaultDonationAmount
 	);
 	const [currency, setCurrency] = useState<CurrencyOption>(
 		mergedConfig.currencies[0]

--- a/packages/donate-button-beta/src/components/widget/types/widget-config.ts
+++ b/packages/donate-button-beta/src/components/widget/types/widget-config.ts
@@ -16,10 +16,7 @@ export type WidgetConfig = {
 	countrySelection: boolean;
 	primaryColor: string;
 	forceLanguage: string | false;
-	defaultDonationAmounts: {
-		monthly: number;
-		oneTime: number;
-	};
+	defaultDonationAmount: number;
 	currencies: CurrencyOption[];
 	defaultFrequency: DonationFrequency;
 	showInitialMessage: boolean;

--- a/packages/donate-button-beta/src/helpers/options-types.ts
+++ b/packages/donate-button-beta/src/helpers/options-types.ts
@@ -45,10 +45,7 @@ const defaults: Partial<WidgetConfig> = {
 	crypto: false,
 	forceLanguage: false,
 	countrySelection: true,
-	defaultDonationAmounts: {
-		monthly: 5,
-		oneTime: 100
-	},
+	defaultDonationAmount: 25,
 	currencies: [
 		{countriesCode: ['AU'], name: 'AUD', symbol: '$', minimumAmount: 10},
 		{countriesCode: ['US'], name: 'USD', symbol: '$', minimumAmount: 10},


### PR DESCRIPTION
closes #201 

@micamastro I made some changes to match what we have on the old widget. 
I think that makes more sense to only have one default donation amount (because we don't want to change it on each frequency change) that is set at the beginning.