### PR TITLE
Fix donate button host link handling

### DIFF
--- a/packages/donate-button-v4/src/autoPlayMode.tsx
+++ b/packages/donate-button-v4/src/autoPlayMode.tsx
@@ -147,6 +147,8 @@ function findAndReplaceLinks() {
 			} else {
 				link.addEventListener('click', (event) => {
 					event.preventDefault();
+					event.stopPropagation();
+					event.stopImmediatePropagation();
 					widget.show();
 				});
 			}

--- a/packages/donate-button-v4/src/components/embed-button/index.tsx
+++ b/packages/donate-button-v4/src/components/embed-button/index.tsx
@@ -40,6 +40,8 @@ const EmbedButton = ({
 				onClick
 					? (event) => {
 							event.preventDefault();
+							event.stopPropagation();
+							event.stopImmediatePropagation();
 							onClick();
 					  }
 					: undefined

--- a/packages/donate-button-v4/src/manualMode.tsx
+++ b/packages/donate-button-v4/src/manualMode.tsx
@@ -108,6 +108,8 @@ export default function manualMode() {
 		});
 		return (event: Event) => {
 			event.preventDefault();
+			event.stopPropagation();
+			event.stopImmediatePropagation();
 			instanceOptions = optionsCopy;
 			showWidget();
 		};


### PR DESCRIPTION
The donate button now stops click propagation when it handles a donate link and opens the embedded widget. This prevents host-site delegated click handlers, like Wix’s, from also opening the Every.org donation URL in a new tab after our modal opens.